### PR TITLE
Issue #81: Remove callback that does not exist

### DIFF
--- a/db/events.php
+++ b/db/events.php
@@ -66,10 +66,6 @@ $observers = [
         'callback'  => 'plagiarism_copyleaks_observer::assign_submission_file_updated',
     ],
     [
-        'eventname' => '\assignsubmission_onlinetext\event\submission_updated',
-        'callback'  => 'plagiarism_copyleaks_observer::assign_submission_text_updated',
-    ],
-    [
         'eventname' => '\assignsubmission_comments\event\comment_created',
         'callback'  => 'plagiarism_copyleaks_observer::assign_submission_comment_created',
     ],


### PR DESCRIPTION
**Description:** Resolves Issue #81. Non-existent callback is causing unit test errors. We remove it's definition/register

### Before

```
root@8b401fdd09dd:/var/www/site# vendor/bin/phpunit --filter test_remove_own_submission_reopened mod/assign/tests/external/remove_submission_test.php
Moodle 4.5.10+ (Build: 20260306), ef6f53e1dfb586e983d827cfc655b294301be80e
Php: 8.3.27, mysqli: 8.0.45, OS: Linux 6.17.0-14-generic x86_64
PHPUnit 9.6.18 by Sebastian Bergmann and contributors.

E                                                                   1 / 1 (100%)

Time: 00:00.503, Memory: 97.00 MB

There was 1 error:

1) mod_assign\external\remove_submission_test::test_remove_own_submission_reopened
Unexpected debugging() call detected.
Debugging: Can not execute event observer 'plagiarism_copyleaks_observer::assign_submission_text_updated'
* line 164 of /lib/classes/event/manager.php: call to debugging()
* line 75 of /lib/classes/event/manager.php: call to core\event\manager::process_buffers()
* line 795 of /lib/classes/event/base.php: call to core\event\manager::dispatch()
* line 295 of /mod/assign/submission/onlinetext/locallib.php: call to core\event\base->trigger()
* line 7680 of /mod/assign/locallib.php: call to assign_submission_onlinetext->save()
* line 85 of /mod/assign/tests/generator.php: call to assign->save_submission()
* line 213 of /mod/assign/tests/external/remove_submission_test.php: call to mod_assign\external\remove_submission_test->add_submission()
* line 1617 of /vendor/phpunit/phpunit/src/Framework/TestCase.php: call to mod_assign\external\remove_submission_test->test_remove_own_submission_reopened()
* line 1223 of /vendor/phpunit/phpunit/src/Framework/TestCase.php: call to PHPUnit\Framework\TestCase->runTest()
* line 76 of /lib/phpunit/classes/advanced_testcase.php: call to PHPUnit\Framework\TestCase->runBare()
* line 729 of /vendor/phpunit/phpunit/src/Framework/TestResult.php: call to advanced_testcase->runBare()
* line 973 of /vendor/phpunit/phpunit/src/Framework/TestCase.php: call to PHPUnit\Framework\TestResult->run()
* line 685 of /vendor/phpunit/phpunit/src/Framework/TestSuite.php: call to PHPUnit\Framework\TestCase->run()
* line 651 of /vendor/phpunit/phpunit/src/TextUI/TestRunner.php: call to PHPUnit\Framework\TestSuite->run()
* line 146 of /vendor/phpunit/phpunit/src/TextUI/Command.php: call to PHPUnit\TextUI\TestRunner->run()
* line 99 of /vendor/phpunit/phpunit/src/TextUI/Command.php: call to PHPUnit\TextUI\Command->run()
* line 107 of /vendor/phpunit/phpunit/phpunit: call to PHPUnit\TextUI\Command::main()
* line 122 of /vendor/bin/phpunit: call to include()


/var/www/site/lib/phpunit/classes/advanced_testcase.php:101

ERRORS!
Tests: 1, Assertions: 3, Errors: 1.
```

### After

```
root@8b401fdd09dd:/var/www/site# vendor/bin/phpunit --filter test_remove_own_submission_reopened mod/assign/tests/external/remove_submission_test.php
Moodle 4.5.10+ (Build: 20260306), ef6f53e1dfb586e983d827cfc655b294301be80e
Php: 8.3.27, mysqli: 8.0.45, OS: Linux 6.17.0-14-generic x86_64
PHPUnit 9.6.18 by Sebastian Bergmann and contributors.

.                                                                   1 / 1 (100%)

Time: 00:01.039, Memory: 97.00 MB

OK (1 test, 3 assertions)
```